### PR TITLE
fix: ShareX Logo not rendering

### DIFF
--- a/src/pages/account/Embed.jsx
+++ b/src/pages/account/Embed.jsx
@@ -5,7 +5,6 @@ import {
   Button,
   minorScale,
   toaster,
-  Alert,
   majorScale,
   Heading,
   TextInputField,
@@ -128,7 +127,7 @@ class AccountEmbed extends PureComponent {
               </div>
               <div className={styles.embedDescription}>{description}</div>
               <a className={styles.embedImage}>
-                <img src="https://send.thigh.pics/ecbEf65.png" />
+                <img src="https://catgirls.shop/emFb849d5ad0B92aa9.png" />
               </a>
             </div>
           </div>


### PR DESCRIPTION
With the latest update to pxl.blue the ShareX image in the embed preview doesn't load properly anymore, replaced the old URL with a new one that works.
Also removed a useless import within the file. 